### PR TITLE
fix issues when running on windows

### DIFF
--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -4,3 +4,4 @@ scipy
 pyspark
 tqdm
 pytest
+findspark

--- a/src/configs/shared.py
+++ b/src/configs/shared.py
@@ -7,6 +7,36 @@ from pyspark.sql.types import (
     LongType,
     BooleanType,
 )
+import platform
+
+# Check if running on Windows
+is_windows = platform.system() == "Windows"
+
+# Windows reserved device names
+windows_reserved_names = [
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9",
+]
 
 # Path of current file
 current_file_path = Path(__file__).resolve()

--- a/src/data_pipeline/spark/data_download.py
+++ b/src/data_pipeline/spark/data_download.py
@@ -2,17 +2,20 @@ import pandas as pd
 import yfinance as yf
 import src.configs as configs
 from tqdm import tqdm
+from src.utils import mkpath
 
 # silent SettingWithCopyWarning
 pd.options.mode.chained_assignment = None  # default='warn'
 
 
 def download_symbols(logger):
+    url = "https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqtraded.txt"
+
     data = pd.read_csv(
-        "https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqtraded.txt",
+        url,
         sep="|",
         dtype={"Symbol": str, "Symbol": str},
-        keep_default_na=False,  # This prevents Pandas from interpreting "NA" as NaN
+        keep_default_na=False,  # This prevents Pandas from interpreting "NA" symbol as NaN
     )
     data_clean = data[data["Test Issue"] == "N"]
 
@@ -38,6 +41,10 @@ def save_symbols(symbols, data_clean, logger):
 
     for i in tqdm(range(configs.offset, end)):
         s = symbols[i]
+        if s.upper() in configs.windows_reserved_names:
+            logger.error(f"Skipping {s} due to Windows reserved name")
+            is_failed[i] = True
+            continue
 
         attempts = 0
         while attempts < 3:

--- a/tests/data_pipeline/spark/conftest.py
+++ b/tests/data_pipeline/spark/conftest.py
@@ -57,7 +57,6 @@ def mock_yf_download(monkeypatch):
 @pytest.fixture(scope="session")
 def spark_session():
     findspark.init()
-    findspark.find()
     spark = SparkSession.builder.appName("test").getOrCreate()
     yield spark
     spark.stop()

--- a/tests/data_pipeline/spark/conftest.py
+++ b/tests/data_pipeline/spark/conftest.py
@@ -16,6 +16,21 @@ def logger():
 
 
 @pytest.fixture(scope="module")
+def windows_reserved_symbols():
+    symbols = configs.windows_reserved_names
+    return symbols
+
+
+@pytest.fixture(scope="module")
+def windows_reserved_data_clean(windows_reserved_symbols):
+    return pd.DataFrame(
+        {
+            "Symbol": windows_reserved_symbols,
+        }
+    )
+
+
+@pytest.fixture(scope="module")
 def symbols():
     symbols = ["AA", "ABEO", "AB", "ACONW", "AC"]  # ACONW should fail
     return symbols

--- a/tests/data_pipeline/spark/conftest.py
+++ b/tests/data_pipeline/spark/conftest.py
@@ -1,13 +1,13 @@
 import pytest
 import os
 import csv
-from pyspark.sql import SparkSession
-from pathlib import Path
 import src.configs as configs
 from unittest.mock import Mock
 import shutil
 import pandas as pd
 import yfinance as yf
+import findspark
+from pyspark.sql import SparkSession
 
 
 @pytest.fixture(scope="module")
@@ -56,6 +56,8 @@ def mock_yf_download(monkeypatch):
 
 @pytest.fixture(scope="session")
 def spark_session():
+    findspark.init()
+    findspark.find()
     spark = SparkSession.builder.appName("test").getOrCreate()
     yield spark
     spark.stop()

--- a/tests/data_pipeline/spark/test_data_download.py
+++ b/tests/data_pipeline/spark/test_data_download.py
@@ -81,7 +81,7 @@ def test_save_symbols(symbols, logger, data_clean, mock_configs, mock_yf_downloa
 
 
 def test_handle_windows_reserved_device_names(
-    windows_reserved_symbols, windows_reserved_data_clean, mock_logger
+    windows_reserved_symbols, windows_reserved_data_clean, mock_logger, mock_configs
 ):
     assert (
         len(

--- a/tests/data_pipeline/spark/test_data_download.py
+++ b/tests/data_pipeline/spark/test_data_download.py
@@ -78,3 +78,16 @@ def test_save_symbols(symbols, logger, data_clean, mock_configs, mock_yf_downloa
     for csv_file in configs.dps_raw.glob("*.csv"):
         df = pd.read_csv(csv_file)
         assert df["Volume"].dtype == "int64"
+
+
+def test_handle_windows_reserved_device_names(
+    windows_reserved_symbols, windows_reserved_data_clean, mock_logger
+):
+    assert (
+        len(
+            save_symbols(
+                windows_reserved_symbols, windows_reserved_data_clean, mock_logger
+            )
+        )
+        == 0
+    )

--- a/tests/data_pipeline/spark/test_data_processing.py
+++ b/tests/data_pipeline/spark/test_data_processing.py
@@ -17,6 +17,7 @@ from pyspark.sql.types import (
 )
 import pytest
 from pathlib import Path
+import findspark
 
 
 @pytest.fixture
@@ -177,3 +178,8 @@ def test_process(mock_logger, mock_spark_session, mock_clean_stock_data):
 
     # Assert that clean_stock_data was called correctly
     mock_clean_stock_data.assert_called_once_with(mock_spark_session, mock_logger)
+
+
+def test_findspark_successful():
+    findspark.init()
+    assert findspark.find()


### PR DESCRIPTION
add findspark to tests requirements.txt, add windows reserved device names to configs and exclude the symbols from further processing in data_download.py